### PR TITLE
Added ping interval to prevent connection 'end' events

### DIFF
--- a/lib/prerenderRedisCache.js
+++ b/lib/prerenderRedisCache.js
@@ -19,6 +19,8 @@ var redis_url = process.env.REDISTOGO_URL || process.env.REDISCLOUD_URL || proce
 if (connection.auth) {
     client.auth(connection.auth.split(":")[1]);
 }
+// Ping redis every 180 seconds to keep connection alive
+setInterval(client.ping(), 1000 * 180);
 
 // Catch all error handler. If redis breaks for any reason it will be reported here.
 client.on("error", function (err) {


### PR DESCRIPTION
I noticed console messages "Redis Cache Connected" if the server was idle, it was the result of the client disconnecting and re-connecting. To fix it, I added a ping.
