### PR TITLE
Pass the ping function, don't call it.

### DIFF
--- a/lib/prerenderRedisCache.js
+++ b/lib/prerenderRedisCache.js
@@ -20,7 +20,7 @@ if (connection.auth) {
     client.auth(connection.auth.split(":")[1]);
 }
 // Ping redis every 180 seconds to keep connection alive
-setInterval(client.ping(), 1000 * 180);
+setInterval(client.ping, 1000 * 180);
 
 // Catch all error handler. If redis breaks for any reason it will be reported here.
 client.on("error", function (err) {


### PR DESCRIPTION
I got some errors which made prerender crash, seems like this was the cause.

```
timers.js:265
    callback.apply(this, args);
             ^
TypeError: undefined is not a function
    at wrapper [as _onTimeout] (timers.js:265:14)
    at Timer.listOnTimeout (timers.js:110:15)
```
