### PR TITLE
Improve the URL parser to read the database number from the URL path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Then in the server.js that initializes the prerender:
 Configuration
 -------------
 
-By default it will connect to your Redis instance running on localhost and the default redis port with no authentication. You can overwrite this by setting the `REDISTOGO_URL`, `REDISCLOUD_URL`, `REDISGREEN_URL` or `REDIS_URL` (in the format redis://user:password@host:port). This currently covers all heroku add-ons for Redis to support quick start.
+By default it will connect to your Redis instance running on localhost and the default redis port with no authentication, and the default database number (normally 0). You can overwrite this by setting the `REDISTOGO_URL`, `REDISCLOUD_URL`, `REDISGREEN_URL` or `REDIS_URL` (in the format redis://user:password@host:port/databaseNumber). This currently covers all heroku add-ons for Redis to support quick start.
 
 Todo
 ----

--- a/lib/prerenderRedisCache.js
+++ b/lib/prerenderRedisCache.js
@@ -7,13 +7,18 @@ var redis_url = process.env.REDISTOGO_URL || process.env.REDISCLOUD_URL || proce
     url = require('url'),
     ttl = process.env.PAGE_TTL || 86400;
 
-    // Parse out the connection vars from the env string.
-    var connection = url.parse(redis_url),
+// Parse out the connection vars from the env string.
+var connection = url.parse(redis_url),
     redis = require('redis'),
     client = redis.createClient(connection.port, connection.hostname),
     redis_online = false,
     last_error = "",
     last_end_message = ""; // Make redis connection
+
+// Select Redis database, parsed from the URL
+connection.path = (connection.pathname || '/').slice(1);
+connection.database = connection.path.length ? connection.path : '0';
+client.select(connection.database);
 
 // Parse out password from the connection string
 if (connection.auth) {


### PR DESCRIPTION
By default, Redis stores all keys in the database number 0, but in some cases we need to work with other database numbers. With this modification we can parse de database number from the URL path, as we can do with other Redis packages. For example: redis://user:password@hostname:port/databaseNumber.
