### PR TITLE
Fixes #18 NOAUTH Authentication required

### DIFF
--- a/lib/prerenderRedisCache.js
+++ b/lib/prerenderRedisCache.js
@@ -32,16 +32,16 @@ var STATUS_CODES_TO_CACHE = {
     501: true
 };
 
+// Parse out password from the connection string
+if (connection.auth) {
+    client.auth(connection.auth.split(':')[1]);
+}
+
 // Make redis connection
 // Select Redis database, parsed from the URL
 connection.path = (connection.pathname || '/').slice(1);
 connection.database = connection.path.length ? connection.path : '0';
 client.select(connection.database);
-
-// Parse out password from the connection string
-if (connection.auth) {
-    client.auth(connection.auth.split(':')[1]);
-}
 
 // Catch all error handler. If redis breaks for any reason it will be reported here.
 client.on('error', function (error) {


### PR DESCRIPTION
Simple fix to prevent the redis client error: NOAUTH Authentication required.

Problem: with redis instances that require auth, `client.select` was called before `client.auth`

Solution: Reorder the code to first call `client.auth`

Another simple solution would be to simply pass REDIS_URL to the `createClient` function. The code `if (connection.auth)` would then be redundant
```
var client = redis.createClient(REDIS_URL);
```
Ref: https://github.com/NodeRedis/node-redis/tree/v.2.8.0#rediscreateclient
```
redis.createClient(redis_url[, options])
```